### PR TITLE
Fix finding repeated word bug

### DIFF
--- a/test-find-trie.js
+++ b/test-find-trie.js
@@ -1,5 +1,6 @@
 var fs = require("fs"),
 	util = require("./util.js");
+	assert = require("assert");
 
 fs.readFile( "dict/string.txt", "utf8", function( err, data ) {
 	var words = data.split(" ");
@@ -22,5 +23,8 @@ fs.readFile( "dict/string.txt", "utf8", function( err, data ) {
 		}
 
 		console.log( (new Date).getTime() - start );
+
+		assert.ok(util.findTrieWord('aals'));
+		assert.ok(!util.findTrieWord('aalsaals'));
 	});
 });

--- a/util.js
+++ b/util.js
@@ -31,6 +31,10 @@ exports.buildHashDict = function( txt ) {
 };
 
 exports.findTrieWord = function findTrieWord( word, cur ) {
+	if ( cur === 0 ) {
+		return false;
+	}
+
 	cur = cur || dict;
 
 	for ( var node in cur ) {


### PR DESCRIPTION
util.findTrieWord() have a bug.

It returns true when finding 'aalsaals' if there is 'aals' and no 'aalsaals' in trie.
