### PR TITLE
Sort `words` before building trie

### DIFF
--- a/build-trie.js
+++ b/build-trie.js
@@ -1,5 +1,5 @@
 var txt = require("fs").readFileSync("dict/string.txt", "utf8"),
-	words = txt.replace(/\n/g, "").split(" "),
+	words = txt.replace(/\n/g, "").split(" ").sort(),
 	trie = {},
 	end = {},
 	keepEnd = {},


### PR DESCRIPTION
To ensure the trie is generated properly, the array of words should be sorted before building the trie structure.
